### PR TITLE
Fix typos: NGramCPS handles 6,005,142 TMs, not 6,005,138 TMs, in Coq-BB5

### DIFF
--- a/sections/decider-2-NGramCPS.tex
+++ b/sections/decider-2-NGramCPS.tex
@@ -115,10 +115,10 @@ The \ngramcps decider becomes particularly powerful for deciding 5-state 2-symbo
     \begin{tabular}{|l|r|}
         \hline
         Variant                                              & Nonhalt   \\  \hline
-        NGram-CPS without augmentation                       & 5,117,863 \\
+        NGram-CPS without augmentation                       & 5,117,867 \\
         NGram-CPS augmented using fixed-length history       & 887,093   \\
         NGram-CPS augmented using Least Recent Usage history & 182       \\ \hline
-        Total decided                                        & 6,005,138 \\
+        Total decided                                        & 6,005,142 \\
         \hline
     \end{tabular}
     \caption{\ngramcps results in the $S(5)$ pipeline (see Table~\ref{tab:pipelineBB5}) per variant (see Section~\ref{sec:n-gramCPS:augmentations}).}\label{tab:ngramcps:results}

--- a/submissions/bbchallenge-paper_arXiv/sections/decider-2-NGramCPS.tex
+++ b/submissions/bbchallenge-paper_arXiv/sections/decider-2-NGramCPS.tex
@@ -114,10 +114,10 @@ The \ngramcps decider becomes particularly powerful for deciding 5-state 2-symbo
     \begin{tabular}{|l|r|}
         \hline
         Variant                                              & Nonhalt   \\  \hline
-        NGram-CPS without augmentation                       & 5,117,863 \\
+        NGram-CPS without augmentation                       & 5,117,867 \\
         NGram-CPS augmented using fixed-length history       & 887,093   \\
         NGram-CPS augmented using Least Recent Usage history & 182       \\ \hline
-        Total decided                                        & 6,005,138 \\
+        Total decided                                        & 6,005,142 \\
         \hline
     \end{tabular}
     \caption{\ngramcps results in the $S(5)$ pipeline (see Table~\ref{tab:pipelineBB5}) per variant (see Section~\ref{sec:n-gramCPS:augmentations}).}\label{tab:ngramcps:results}

--- a/submissions/bbchallenge-paper_arXiv_v2/sections/decider-2-NGramCPS.tex
+++ b/submissions/bbchallenge-paper_arXiv_v2/sections/decider-2-NGramCPS.tex
@@ -114,10 +114,10 @@ The \ngramcps decider becomes particularly powerful for deciding 5-state 2-symbo
     \begin{tabular}{|l|r|}
         \hline
         Variant                                              & Nonhalt   \\  \hline
-        NGram-CPS without augmentation                       & 5,117,863 \\
+        NGram-CPS without augmentation                       & 5,117,867 \\
         NGram-CPS augmented using fixed-length history       & 887,093   \\
         NGram-CPS augmented using Least Recent Usage history & 182       \\ \hline
-        Total decided                                        & 6,005,138 \\
+        Total decided                                        & 6,005,142 \\
         \hline
     \end{tabular}
     \caption{\ngramcps results in the $S(5)$ pipeline (see Table~\ref{tab:pipelineBB5}) per variant (see Section~\ref{sec:n-gramCPS:augmentations}).}\label{tab:ngramcps:results}


### PR DESCRIPTION
The discrepancy comes from the fact that 3291498+1328432+497142+795 = 5117867, which is 4 off from 5,117,863 for "NGram-CPS without augmentation" stated in 4.4.3